### PR TITLE
feat: add link management features with create link form and link list

### DIFF
--- a/lib/models/link.dart
+++ b/lib/models/link.dart
@@ -1,0 +1,34 @@
+class Link {
+  final String url;
+  final String shortenedUrl;
+  final String title;
+  final String description;
+
+  Link({
+    required this.url,
+    required this.shortenedUrl,
+    required this.title,
+    required this.description,
+  });
+
+  @override
+  String toString() {
+    return 'Link(url: $url, title: $title, description: $description)';
+  }
+
+  String get displayTitle {
+    return title.isNotEmpty ? title : 'No Title';
+  }
+
+  String get displayDescription {
+    return description.isNotEmpty ? description : 'No Description';
+  }
+
+  String get displayUrl {
+    return url.isNotEmpty ? url : 'No URL';
+  }
+
+  String get displayShortenedUrl {
+    return shortenedUrl.isNotEmpty ? shortenedUrl : 'No Shortened URL';
+  }
+}

--- a/lib/screens/create_link_screen.dart
+++ b/lib/screens/create_link_screen.dart
@@ -1,0 +1,53 @@
+import 'dart:developer';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_application_1/widgets/create_link_form.dart';
+
+class CreateLinkScreen extends StatelessWidget {
+  const CreateLinkScreen({super.key});
+
+  void onCreateLink(String title, String description) {
+    // Handle the link creation logic here
+    // For example, you could send this data to a server or save it locally
+    log('Link created with title: $title and description: $description');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Create Link'),
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+      ),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Text('Create a new link here'),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: () {
+                  // Implement your link creation logic here
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Link created!')),
+                  );
+                },
+                child: CreateLinkForm(onCreateLink: onCreateLink),
+              ),
+            ],
+          ),
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          // Navigate back to the dashboard or another screen
+          Navigator.pop(context);
+        },
+        backgroundColor: Theme.of(context).colorScheme.primary,
+        child: const Icon(Icons.arrow_back),
+      ),
+    );
+  }
+}

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -1,9 +1,17 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import '../widgets/login_form.dart';
+import 'package:flutter_application_1/models/link.dart';
+import 'package:flutter_application_1/screens/create_link_screen.dart';
+import 'package:flutter_application_1/widgets/link_list.dart';
 
 class DashboardScreen extends StatelessWidget {
   const DashboardScreen({super.key});
+
+  void onAddButtonPressed(BuildContext context) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const CreateLinkScreen()),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -15,11 +23,28 @@ class DashboardScreen extends StatelessWidget {
       body: Center(
         child: Padding(
           padding: const EdgeInsets.all(16),
-          child: Text(
-            'Welcome to the Dashboard!',
-            style: Theme.of(context).textTheme.headlineMedium,
+          child: LinkList(
+            links: [
+              Link(
+                url: 'url',
+                shortenedUrl: 'shortenedUrl',
+                title: 'title',
+                description: 'description',
+              ),
+            ],
+            onLinkTap: (link) {
+              final linkMap = link as Map<String, String>;
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(content: Text('Tapped on ${linkMap['title']}')),
+              );
+            },
           ),
         ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => onAddButtonPressed(context),
+        backgroundColor: Theme.of(context).colorScheme.primary,
+        child: const Icon(Icons.add),
       ),
     );
   }

--- a/lib/widgets/create_link_form.dart
+++ b/lib/widgets/create_link_form.dart
@@ -1,0 +1,74 @@
+import 'dart:developer';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class CreateLinkForm extends StatefulWidget {
+  final void Function(String title, String description) onCreateLink;
+
+  const CreateLinkForm({super.key, required this.onCreateLink});
+
+  @override
+  State<CreateLinkForm> createState() => _CreateLinkFormState();
+}
+
+class _CreateLinkFormState extends State<CreateLinkForm> {
+  final _formKey = GlobalKey<FormState>();
+  final _titleController = TextEditingController();
+  final _descriptionController = TextEditingController();
+
+  void handleCreateLink() {
+    if (_formKey.currentState?.validate() ?? false) {
+      final title = _titleController.text;
+      final description = _descriptionController.text;
+
+      widget.onCreateLink(title, description);
+      log("title: $title, description: $description");
+    }
+    // Implement your login logic here
+    log("Login button pressed");
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Form(
+      key: _formKey,
+      child: Column(
+        children: [
+          TextFormField(
+            controller: _titleController,
+            validator: (value) {
+              if (value == null || value.isEmpty) {
+                return "Please enter your link's name";
+              }
+              return null;
+            },
+            decoration: const InputDecoration(
+              labelText: "Link's Name",
+              hintText: "Enter your link's name",
+            ),
+            keyboardType: TextInputType.text,
+            inputFormatters: [
+              FilteringTextInputFormatter.allow(RegExp(r'[a-zA-Z0-9@._-]')),
+            ],
+          ),
+          const SizedBox(height: 16.0),
+          TextFormField(
+            controller: _descriptionController,
+            decoration: InputDecoration(
+              labelText: 'Description',
+              hintText: 'Enter an description for your link (optional)',
+              alignLabelWithHint: true,
+            ),
+            inputFormatters: [FilteringTextInputFormatter.deny(RegExp(r'\s'))],
+            keyboardType: TextInputType.multiline,
+            minLines: 3,
+            maxLines: 5,
+          ),
+          const SizedBox(height: 16.0),
+          ElevatedButton(onPressed: handleCreateLink, child: const Text("Login")),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/link_list.dart
+++ b/lib/widgets/link_list.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_application_1/models/link.dart';
+
+class LinkList extends StatefulWidget {
+  final List<Link> links;
+  final void Function(Object) onLinkTap;
+  const LinkList({super.key, required this.links, required this.onLinkTap});
+  @override
+  State<LinkList> createState() => _LinkListState();
+}
+
+class _LinkListState extends State<LinkList> {
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      itemCount: widget.links.length,
+      itemBuilder: (context, index) {
+        final link = widget.links[index];
+        return ListTile(
+          title: Text(link.displayTitle),
+          onTap: () => widget.onLinkTap(link),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
This pull request introduces a feature for managing and displaying links in a Flutter application. The key changes include adding a new `Link` model, implementing a form and screen for creating links, and integrating a list view to display links on the dashboard. Below are the most important changes grouped by theme:

### Core Model Addition:
* **`lib/models/link.dart`**: Introduced a new `Link` class to encapsulate link-related data such as `url`, `shortenedUrl`, `title`, and `description`. Includes utility methods for displaying default values when fields are empty.

### Link Creation Feature:
* **`lib/screens/create_link_screen.dart`**: Added a new `CreateLinkScreen` with a form and logic for creating links. Includes a floating action button for navigation and a snackbar to confirm link creation.
* **`lib/widgets/create_link_form.dart`**: Implemented the `CreateLinkForm` widget with validation for link title and description inputs. Includes a callback for handling link creation.

### Dashboard Enhancements:
* **`lib/screens/dashboard_screen.dart`**: Updated the dashboard to include a `LinkList` widget for displaying links and added a floating action button to navigate to the `CreateLinkScreen`. [[1]](diffhunk://#diff-688acc40438ac47048449d5d83d04a1c5e57b0315433d6ef05efa03ef1574f2fL2-R15) [[2]](diffhunk://#diff-688acc40438ac47048449d5d83d04a1c5e57b0315433d6ef05efa03ef1574f2fL18-R47)

### Link Display:
* **`lib/widgets/link_list.dart`**: Created the `LinkList` widget to display a list of links using a `ListView.builder`. Includes a tap handler for user interaction with individual links.